### PR TITLE
README.md: Adds Debian installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Installing the Taskwarrior segment can be done with pip:
 pip install powerline-taskwarrior
 ```
 
+On Debian (testing or unstable), installation can be performed with apt:
+
+```txt
+apt install python-powerline-taskwarrior
+```
+
 Then you can activate the Taskwarrior segment by adding it to your segment configuration,
 for example in `~/.config/powerline/themes/shell/default.json`:
 


### PR DESCRIPTION
Adds installation instructions for Debian, but only for testing and unstable. This package is not in a stable release nor does it currently have a backport to stable.

Currently the package is only in unstable, so this probably shouldn't be merged for 10 days, allowing the package to migrate to testing.

https://release.debian.org/migration/testing.pl?package=powerline-taskwarrior (link not active yet but this is where the migration status will be)